### PR TITLE
`def --env` fix

### DIFF
--- a/checks/envScript/default.nix
+++ b/checks/envScript/default.nix
@@ -39,6 +39,13 @@ pkgs.nuenv.mkDerivation {
       assert equal $env.PATH [ ]
     }
 
+    do {
+      let old_path = $env.PATH
+      one-calls-another
+      # Check that PATH was not changed after running
+      assert equal $env.PATH $old_path
+    }
+
     mkdir $env.out
   '';
 }

--- a/checks/envScript/mod.nu
+++ b/checks/envScript/mod.nu
@@ -18,3 +18,13 @@ export def --env clear-path []: nothing -> nothing {
   check-jq-installed
   $env.PATH = []
 }
+
+export def --env another []: nothing -> nothing {
+  check-jq-installed
+}
+
+export def --env one-calls-another []: nothing -> nothing {
+  check-jq-installed
+  another
+  check-jq-installed
+}


### PR DESCRIPTION
Fix `$env.PATH` cleared too early when `export def --env` commands call each other